### PR TITLE
Handle fullscreen errors when starting task

### DIFF
--- a/mrt.js
+++ b/mrt.js
@@ -372,9 +372,14 @@ function nextTrial(){
 
   // ---------- Start / Resize ----------
   fsBtn.addEventListener('click', async () => {
-    await enterFullscreenIfPossible();
-    fsOverlay.style.display = 'none';
-    ibox.style.display = 'block';
+    try {
+      if (!isEmbedded) await enterFullscreenIfPossible();
+    } catch (_) {
+      // Ignore fullscreen errors
+    } finally {
+      fsOverlay.style.display = 'none';
+      ibox.style.display = 'block';
+    }
   });
 
   startPracticeBtn.addEventListener('click', startPractice);


### PR DESCRIPTION
## Summary
- Wrap fullscreen request in try/catch/finally to always hide overlay and show intro box
- Skip fullscreen request when running inside an iframe

## Testing
- `node --check mrt.js`
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/mrt/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a8bba39848326b7a8c4e41aea6f23