### PR TITLE
Add pointerup listener for Start button

### DIFF
--- a/mrt.js
+++ b/mrt.js
@@ -382,7 +382,9 @@ function nextTrial(){
     }
   });
 
-  startPracticeBtn.addEventListener('click', startPractice);
+  const startPracticeHandler = () => startPractice();
+  startPracticeBtn.addEventListener('click', startPracticeHandler);
+  startPracticeBtn.addEventListener('pointerup', startPracticeHandler);
 
   window.addEventListener('resize', () => {
     if (state.current) layoutAndDraw(state.current);


### PR DESCRIPTION
## Summary
- Share a single handler for the start button
- Handle both click and pointerup events to support pointer input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8cefb4b88326a464f0e9f2f591ab