### PR TITLE
Track MRT participant initials

### DIFF
--- a/mrt.js
+++ b/mrt.js
@@ -410,7 +410,10 @@
     PARTICIPANT_ID = initials;
     RNG_SEED = hashCode(SESSION_CODE || PARTICIPANT_ID || (Date.now() + ''));
     state.rng = mulberry32(RNG_SEED);
-    
+
+    // Register participant on the tracking sheet
+    await sendToSheets({ action: 'participant', timestamp: new Date().toISOString() });
+
     try {
       if (!isEmbedded) await enterFullscreenIfPossible();
     } catch (_) {


### PR DESCRIPTION
## Summary
- Record participant initials in a separate `mrt_tracking` sheet via Apps Script
- Log participants once per session without overwriting existing entries
- Send participant registration from the MRT client on task start

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8da9eb1208326af51938eb553a14b