### PR TITLE
Limit MRT session to 140 main trials

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,6 +10,9 @@ window.MRT_CONFIG = {
   TRIALS_PER_PAIR: 2,         // How many times each angle pair appears per condition
                                // With 7 angles: 7×7 = 49 pairs × 2 conditions × 2 reps = 196 trials
                                // Adjust this based on desired experiment length
+
+  // Limit the total number of main trials shown to participants
+  MAX_MAIN_TRIALS: 140,
   
   // ORIGINAL SETTING (used only if USE_ALL_ANGLE_PAIRS is false):
   TRIALS_PER_ANGLE_PER_COND: 10, // For same-angle only mode

--- a/mrt.js
+++ b/mrt.js
@@ -272,7 +272,14 @@
       }
     }
     
-    return shuffle(trials, state.rng);
+    let mainTrials = shuffle(trials, state.rng);
+
+    const maxTrials = CFG.MAX_MAIN_TRIALS;
+    if (Number.isFinite(maxTrials) && maxTrials > 0 && mainTrials.length > maxTrials) {
+      mainTrials = mainTrials.slice(0, maxTrials);
+    }
+
+    return mainTrials;
   }
 
   function makePracticeTrials(n){
@@ -507,7 +514,7 @@
 
     ibox.innerHTML = `
       <h2>Task complete</h2>
-      <p>Thank you for completing the task!</p>
+      <p>Thank you, you may close this window now.</p>
       <p style="margin-top: 10px; color: #9aa;">Participant: ${PARTICIPANT_ID}</p>
       <div class="btnrow">
         <button class="btn secondary" id="closeBtn">Close</button>


### PR DESCRIPTION
## Summary
- add a MAX_MAIN_TRIALS configuration to cap the main block length
- clamp the shuffled main trials list to that limit so the session ends cleanly
- update the completion copy to tell participants "thank you, you may close this window now"

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f10237e92c8326be81caf9422c8765