### PR TITLE
Ensure MRT stops after 140 trials

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,9 +10,10 @@ window.MRT_CONFIG = {
   TRIALS_PER_PAIR: 2,         // How many times each angle pair appears per condition
                                // With 7 angles: 7×7 = 49 pairs × 2 conditions × 2 reps = 196 trials
                                // Adjust this based on desired experiment length
+  MAIN_TRIAL_LIMIT: 140,      // Hard cap on the number of main-task trials (after shuffling)
   
   // ORIGINAL SETTING (used only if USE_ALL_ANGLE_PAIRS is false):
-  TRIALS_PER_ANGLE_PER_COND: 10, // For same-angle only mode
+  TRIALS_PER_ANGLE_PER_COND: 10, // For same-angle only mode (still subject to MAIN_TRIAL_LIMIT)
   
   PRACTICE_TRIALS: 12,
   FIXATION_MS: 700,


### PR DESCRIPTION
## Summary
- add a configurable hard limit for main block trials and apply it after shuffling
- support generating all angle pair trials while still respecting the new limit
- update the completion screen to instruct participants to close the window

## Testing
- not run (web content change)


------
https://chatgpt.com/codex/tasks/task_e_68f427a7b3c083269153ff12685745a1