### PR TITLE
Revert MRT config to same-angle defaults

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,20 +1,10 @@
-// config.js - UPDATED FOR ALL ANGLE PAIR COMBINATIONS
+// config.js
 window.MRT_CONFIG = {
   SHEETS_URL: 'https://script.google.com/macros/s/AKfycbySbIYESXF74p4QXK7BfKyLo8rLWXiMKa5b0jKB66DYLXGK6ZmptUSZmALr7w9ME15Tag/exec', // <-- replace this line
 
   // ===== Design =====
   ANGLES: [0, 30, 60, 90, 120, 150, 180],
-  
-  // NEW SETTINGS FOR ALL PAIRS:
-  USE_ALL_ANGLE_PAIRS: true,  // Set to false to revert to same-angle only
-  TRIALS_PER_PAIR: 2,         // How many times each angle pair appears per condition
-                               // With 7 angles: 7×7 = 49 pairs × 2 conditions × 2 reps = 196 trials
-                               // Adjust this based on desired experiment length
-  MAIN_TRIAL_LIMIT: 140,      // Hard cap on the number of main-task trials (after shuffling)
-  
-  // ORIGINAL SETTING (used only if USE_ALL_ANGLE_PAIRS is false):
-  TRIALS_PER_ANGLE_PER_COND: 10, // For same-angle only mode (still subject to MAIN_TRIAL_LIMIT)
-  
+  TRIALS_PER_ANGLE_PER_COND: 10, // 10 × 7 × 2 = 140 main trials
   PRACTICE_TRIALS: 12,
   FIXATION_MS: 700,
   MAX_RT_MS: 3500,
@@ -36,29 +26,5 @@ window.MRT_CONFIG = {
   FG: '#fff',
 
   // ===== Misc =====
-  VERSION: 'mrt-v2.0-all-pairs',  // Updated version
+  VERSION: 'mrt-v1.3-single-canvas',
 };
-
-/* 
-CONFIGURATION NOTES:
-
-With USE_ALL_ANGLE_PAIRS = true:
-- Total angle pairs: 7 × 7 = 49 unique combinations
-- Each pair appears in both 'same' and 'mirror' conditions
-- TRIALS_PER_PAIR controls repetitions:
-  - 1 rep = 98 trials (49 pairs × 2 conditions)
-  - 2 reps = 196 trials 
-  - 3 reps = 294 trials
-  - 4 reps = 392 trials
-
-To reduce experiment length, you could:
-1. Reduce TRIALS_PER_PAIR to 1
-2. Use fewer angles (e.g., [0, 45, 90, 135, 180] = 5 angles = 50 trials with 1 rep)
-3. Exclude same-angle pairs if desired (would need code modification)
-
-The data now includes:
-- left_angle: rotation of left letter
-- right_angle: rotation of right letter  
-- angle_diff: angular difference between them (0-180°)
-- This allows analysis of RT/accuracy as a function of angular disparity
-*/


### PR DESCRIPTION
## Summary
- restore the MRT configuration to the original same-angle trial settings
- remove the all-angle-pairs options and reset the version identifier to the prior release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f42aea31e08326ae1531f8e2e6d2f2